### PR TITLE
Refactor sections into micro components

### DIFF
--- a/src/components/sections/about/AboutUs.jsx
+++ b/src/components/sections/about/AboutUs.jsx
@@ -1,43 +1,25 @@
 "use client";
 
-import Image from "next/image";
 import Section from "@/components/ui/Section";
 import { about } from "@/lib/data";
+import AboutIllustration from "./components/AboutIllustration";
+import AboutContent from "./components/AboutContent";
 
 export default function AboutUs() {
-    const { id, titleTop, titleMid, titleBottom, paragraphs, cta, image } = about;
+  const { id, titleTop, titleMid, titleBottom, paragraphs, cta, image } = about;
 
-    return (
-        <Section
-            id={id}
-            className="bg-[#FBF1C6] text-[#2B1C0E]"
-            innerClassName="grid grid-cols-1 md:grid-cols-12 py-20 md:py-0 md:pt-20 items-stretch w-full mx-auto relative px-2 md:px-6 max-w-[1480px] gap-2 md:gap-20"
-        >
-            {/* Ilustración (izquierda en desktop) */}
-            <div className="order-2 md:order-1 md:col-span-6 flex items-center justify-center">
-                <div className="relative w-full md:w-[min(60vw,820px)] lg:w-[min(52vw,900px)]">
-                    <div className="relative h-[36vh] sm:h-[52vh] md:h-[min(70vh,720px)] lg:h-[min(76vh,820px)]">
-                        <Image src={image.src} alt={image.alt} fill priority sizes="(max-width: 768px) 95vw, (max-width: 1200px) 55vw, 900px" className="object-contain mt-10 md:mt-0" />
-                    </div>
-                </div>
-            </div>
-
-            {/* Texto (derecha en desktop) */}
-            <div className="order-1 md:order-2 md:col-span-6 flex flex-col justify-center pt-0 md:pt-6 ">
-                <h2 className="font-heading leading-[0.9] tracking-[-0.02em] text-[clamp(38px,6.5vw,5rem)]"> {titleTop}<br className="hidden md:block" /> {titleMid}<br />{titleBottom} </h2>
-
-                <div className="mt-6 space-y-2 md:space-y-6">
-                    {paragraphs.map((p, i) => (
-                        <p key={i} className="text-[#2B1C0E] text-lg sm:text-xl lg:text-2xl font-sub">{p}</p>
-                    ))}
-                </div>
-
-                <div className="mt-2">
-                    <a href={cta.href} className="inline-flex items-center justify-center px-6 sm:px-7 py-3 rounded-[9999px] text-base sm:text-lg font-semibold bg-[#F7D58A] text-[#2B1C0E] border-[3px] border-[#2B1C0E] shadow-[4px_4px_0px_0px_#2B1C0E] hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-none transition-transform duration-150">
-                        {cta.label}
-                    </a>
-                </div>
-            </div>
-        </Section>
-    );
+  return (
+    <Section
+      id={id}
+      className="bg-[#FBF1C6] text-[#2B1C0E]"
+      innerClassName="grid grid-cols-1 md:grid-cols-12 py-20 md:py-0 md:pt-20 items-stretch w-full mx-auto relative px-2 md:px-6 max-w-[1480px] gap-2 md:gap-20"
+    >
+      <AboutIllustration image={image} />
+      <AboutContent
+        title={{ top: titleTop, mid: titleMid, bottom: titleBottom }}
+        paragraphs={paragraphs}
+        cta={cta}
+      />
+    </Section>
+  );
 }

--- a/src/components/sections/about/components/AboutCTA.jsx
+++ b/src/components/sections/about/components/AboutCTA.jsx
@@ -1,0 +1,14 @@
+"use client";
+
+export default function AboutCTA({ cta }) {
+  return (
+    <div className="mt-2">
+      <a
+        href={cta.href}
+        className="inline-flex items-center justify-center px-6 sm:px-7 py-3 rounded-[9999px] text-base sm:text-lg font-semibold bg-[#F7D58A] text-[#2B1C0E] border-[3px] border-[#2B1C0E] shadow-[4px_4px_0px_0px_#2B1C0E] hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-none transition-transform duration-150"
+      >
+        {cta.label}
+      </a>
+    </div>
+  );
+}

--- a/src/components/sections/about/components/AboutContent.jsx
+++ b/src/components/sections/about/components/AboutContent.jsx
@@ -1,0 +1,15 @@
+"use client";
+
+import AboutTitle from "./AboutTitle";
+import AboutParagraphs from "./AboutParagraphs";
+import AboutCTA from "./AboutCTA";
+
+export default function AboutContent({ title, paragraphs, cta }) {
+  return (
+    <div className="order-1 md:order-2 md:col-span-6 flex flex-col justify-center pt-0 md:pt-6">
+      <AboutTitle {...title} />
+      <AboutParagraphs items={paragraphs} />
+      <AboutCTA cta={cta} />
+    </div>
+  );
+}

--- a/src/components/sections/about/components/AboutIllustration.jsx
+++ b/src/components/sections/about/components/AboutIllustration.jsx
@@ -1,0 +1,22 @@
+"use client";
+
+import Image from "next/image";
+
+export default function AboutIllustration({ image }) {
+  return (
+    <div className="order-2 md:order-1 md:col-span-6 flex items-center justify-center">
+      <div className="relative w-full md:w-[min(60vw,820px)] lg:w-[min(52vw,900px)]">
+        <div className="relative h-[36vh] sm:h-[52vh] md:h-[min(70vh,720px)] lg:h-[min(76vh,820px)]">
+          <Image
+            src={image.src}
+            alt={image.alt}
+            fill
+            priority
+            sizes="(max-width: 768px) 95vw, (max-width: 1200px) 55vw, 900px"
+            className="object-contain mt-10 md:mt-0"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/sections/about/components/AboutParagraphs.jsx
+++ b/src/components/sections/about/components/AboutParagraphs.jsx
@@ -1,0 +1,13 @@
+"use client";
+
+export default function AboutParagraphs({ items }) {
+  return (
+    <div className="mt-6 space-y-2 md:space-y-6">
+      {items.map((paragraph, index) => (
+        <p key={index} className="text-[#2B1C0E] text-lg sm:text-xl lg:text-2xl font-sub">
+          {paragraph}
+        </p>
+      ))}
+    </div>
+  );
+}

--- a/src/components/sections/about/components/AboutTitle.jsx
+++ b/src/components/sections/about/components/AboutTitle.jsx
@@ -1,0 +1,12 @@
+"use client";
+
+export default function AboutTitle({ top, mid, bottom }) {
+  return (
+    <h2 className="font-heading leading-[0.9] tracking-[-0.02em] text-[clamp(38px,6.5vw,5rem)]">
+      {top}
+      <br className="hidden md:block" /> {mid}
+      <br />
+      {bottom}
+    </h2>
+  );
+}

--- a/src/components/sections/contact/Contact.jsx
+++ b/src/components/sections/contact/Contact.jsx
@@ -1,80 +1,21 @@
 "use client";
 
-import Image from "next/image";
 import Section from "@/components/ui/Section";
 import { contact } from "@/lib/data";
+import ContactFormSection from "./components/ContactFormSection";
+import ContactIllustration from "./components/ContactIllustration";
 
 export default function Contact() {
-    const { id, title, fields, submit, image, band } = contact;
+  const { id, title, fields, submit, image } = contact;
 
-    return (
-        <Section
-            id={id}
-            className="bg-[#4B4B44] text-[#2B1C0E]"
-            innerClassName="grid grid-cols-1 md:grid-cols-12 items-stretch w-full mx-auto relative px-2 md:px-6 max-w-[1480px] gap-6 md:gap-20 py-20 md:py-0 md:pt-16"
-        >
-            {/* Formulario */}
-            <div className="md:col-span-6 flex flex-col justify-center border-[6px] border-[#2B1C0E] bg-[#FBF1C6] rounded-[28px] p-5 md:p-10 shadow-[6px_6px_0px_0px_#2B1C0E]">
-                <h2 className="font-heading text-[clamp(36px,7vw,72px)] leading-[0.9] tracking-[-0.02em] mb-6">
-                    {title}
-                </h2>
-
-                <form className="w-full flex flex-col gap-5">
-                    {fields.map((field, i) => (
-                        <div key={i} className="flex flex-col gap-1">
-                            <label htmlFor={field.name} className="font-heading text-lg">
-                                {field.label}
-                            </label>
-                            {field.type === "textarea" ? (
-                                <textarea
-                                    id={field.name}
-                                    placeholder={field.placeholder}
-                                    className="w-full rounded-[28px] border-[3px] border-[#2B1C0E] bg-[#F4DFC6]/80 px-4 py-3 shadow-[3px_3px_0px_0px_#2B1C0E] focus:outline-none resize-none"
-                                    rows={4}
-                                />
-                            ) : (
-                                <input
-                                    id={field.name}
-                                    type={field.type}
-                                    placeholder={field.placeholder}
-                                    className="w-full rounded-[28px] border-[3px] border-[#2B1C0E] px-4 bg-[#F4DFC6]/80 py-3 shadow-[3px_3px_0px_0px_#2B1C0E] focus:outline-none"
-                                />
-                            )}
-                        </div>
-                    ))}
-
-                    <button
-                        type="submit"
-                        className="inline-flex cursor-pointer items-center justify-center px-8 py-3 rounded-[9999px] text-lg font-semibold bg-[#B74728] text-[#FFFFFF] border-[3px] border-[#2B1C0E] shadow-[4px_4px_0px_0px_#2B1C0E] hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-none transition-transform duration-150 mt-4"
-                    >
-                        {submit.label}
-                    </button>
-                </form>
-            </div>
-
-            {/* Banana */}
-            <div className="pb-10 md:pb-0 md:col-span-6 flex justify-center md:justify-end items-center">
-                <div className="relative w-full md:w-[min(60vw,600px)] lg:w-[min(56vw,720px)]">
-                    <div className="relative h-[40vh] sm:h-[50vh] md:h-[min(70vh,720px)]">
-                        <Image
-                            src={image.src}
-                            alt={image.alt}
-                            fill
-                            priority
-                            sizes="(max-width: 768px) 90vw, (max-width: 1200px) 50vw, 600px"
-                            className="object-contain mt-10 md:mt-0"
-                        />
-                    </div>
-                </div>
-            </div>
-
-            {/* Franja inferior */}
-            {/*             <div className="md:col-span-12 mt-10">
-                <div className="w-full bg-[#B74728] text-[#FFFFFF] rounded-full flex justify-center items-center px-6 py-3 text-center font-heading text-[clamp(16px,3vw,24px)] shadow-[3px_3px_0px_0px_#2B1C0E]">
-                    <span className="mr-2">{band.icon}</span>
-                    {band.text}
-                </div>
-            </div> */}
-        </Section>
-    );
+  return (
+    <Section
+      id={id}
+      className="bg-[#4B4B44] text-[#2B1C0E]"
+      innerClassName="grid grid-cols-1 md:grid-cols-12 items-stretch w-full mx-auto relative px-2 md:px-6 max-w-[1480px] gap-6 md:gap-20 py-20 md:py-0 md:pt-16"
+    >
+      <ContactFormSection title={title} fields={fields} submit={submit} />
+      <ContactIllustration image={image} />
+    </Section>
+  );
 }

--- a/src/components/sections/contact/components/ContactForm.jsx
+++ b/src/components/sections/contact/components/ContactForm.jsx
@@ -1,0 +1,15 @@
+"use client";
+
+import ContactFormField from "./ContactFormField";
+import ContactSubmitButton from "./ContactSubmitButton";
+
+export default function ContactForm({ fields, submit }) {
+  return (
+    <form className="w-full flex flex-col gap-5">
+      {fields.map((field, index) => (
+        <ContactFormField key={index} field={field} />
+      ))}
+      <ContactSubmitButton label={submit.label} />
+    </form>
+  );
+}

--- a/src/components/sections/contact/components/ContactFormField.jsx
+++ b/src/components/sections/contact/components/ContactFormField.jsx
@@ -1,0 +1,37 @@
+"use client";
+
+function renderField(field) {
+  const baseClasses =
+    "w-full rounded-[28px] border-[3px] border-[#2B1C0E] bg-[#F4DFC6]/80 px-4 py-3 shadow-[3px_3px_0px_0px_#2B1C0E] focus:outline-none";
+
+  if (field.type === "textarea") {
+    return (
+      <textarea
+        id={field.name}
+        placeholder={field.placeholder}
+        className={`${baseClasses} resize-none`}
+        rows={4}
+      />
+    );
+  }
+
+  return (
+    <input
+      id={field.name}
+      type={field.type}
+      placeholder={field.placeholder}
+      className={baseClasses}
+    />
+  );
+}
+
+export default function ContactFormField({ field }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label htmlFor={field.name} className="font-heading text-lg">
+        {field.label}
+      </label>
+      {renderField(field)}
+    </div>
+  );
+}

--- a/src/components/sections/contact/components/ContactFormSection.jsx
+++ b/src/components/sections/contact/components/ContactFormSection.jsx
@@ -1,0 +1,13 @@
+"use client";
+
+import ContactTitle from "./ContactTitle";
+import ContactForm from "./ContactForm";
+
+export default function ContactFormSection({ title, fields, submit }) {
+  return (
+    <div className="md:col-span-6 flex flex-col justify-center border-[6px] border-[#2B1C0E] bg-[#FBF1C6] rounded-[28px] p-5 md:p-10 shadow-[6px_6px_0px_0px_#2B1C0E]">
+      <ContactTitle title={title} />
+      <ContactForm fields={fields} submit={submit} />
+    </div>
+  );
+}

--- a/src/components/sections/contact/components/ContactIllustration.jsx
+++ b/src/components/sections/contact/components/ContactIllustration.jsx
@@ -1,0 +1,22 @@
+"use client";
+
+import Image from "next/image";
+
+export default function ContactIllustration({ image }) {
+  return (
+    <div className="pb-10 md:pb-0 md:col-span-6 flex justify-center md:justify-end items-center">
+      <div className="relative w-full md:w-[min(60vw,600px)] lg:w-[min(56vw,720px)]">
+        <div className="relative h-[40vh] sm:h-[50vh] md:h-[min(70vh,720px)]">
+          <Image
+            src={image.src}
+            alt={image.alt}
+            fill
+            priority
+            sizes="(max-width: 768px) 90vw, (max-width: 1200px) 50vw, 600px"
+            className="object-contain mt-10 md:mt-0"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/sections/contact/components/ContactSubmitButton.jsx
+++ b/src/components/sections/contact/components/ContactSubmitButton.jsx
@@ -1,0 +1,12 @@
+"use client";
+
+export default function ContactSubmitButton({ label }) {
+  return (
+    <button
+      type="submit"
+      className="inline-flex cursor-pointer items-center justify-center px-8 py-3 rounded-[9999px] text-lg font-semibold bg-[#B74728] text-[#FFFFFF] border-[3px] border-[#2B1C0E] shadow-[4px_4px_0px_0px_#2B1C0E] hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-none transition-transform duration-150 mt-4"
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/components/sections/contact/components/ContactTitle.jsx
+++ b/src/components/sections/contact/components/ContactTitle.jsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function ContactTitle({ title }) {
+  return (
+    <h2 className="font-heading text-[clamp(36px,7vw,72px)] leading-[0.9] tracking-[-0.02em] mb-6">
+      {title}
+    </h2>
+  );
+}

--- a/src/components/sections/footer/Footer.jsx
+++ b/src/components/sections/footer/Footer.jsx
@@ -1,10 +1,10 @@
 "use client";
 
-import Image from "next/image";
 import Section from "@/components/ui/Section";
 import { footer } from "@/lib/data";
-import { FaCoffee, FaPhoneAlt, FaEnvelope, FaMapMarkerAlt } from "react-icons/fa";
-import Link from "next/link";
+import FooterBrandCard from "./components/FooterBrandCard";
+import FooterContactCard from "./components/FooterContactCard";
+import FooterNavigation from "./components/FooterNavigation";
 
 export default function Footer() {
   const { id, colors, brand, contactCard, nav, image } = footer;
@@ -15,86 +15,9 @@ export default function Footer() {
       className={`bg-[${colors.bg}] text-[${colors.textLight}]`}
       innerClassName="grid grid-cols-1 md:grid-cols-12 items-stretch w-full mx-auto relative px-2 md:px-6 max-w-[1480px] gap-6 md:gap-10 pt-10 md:pt-16 pb-12"
     >
-      {/* Tarjeta marca */}
-      <div className="md:col-span-7">
-        <div className="w-full h-full min-h-[280px] md:min-h-[340px] rounded-[28px] border-[6px] border-[#2B1C0E] bg-[#F4DFC6] p-6 md:p-10 shadow-[6px_6px_0px_0px_#2B1C0E] flex flex-col justify-center">
-          <h3 className="font-heading text-[#2B1C0E] leading-[0.85] tracking-[-0.02em] text-[clamp(46px,7vw,96px)]">
-            {brand.titleTop}
-          </h3>
-          <h3 className="font-heading text-[#2B1C0E] leading-[0.85] tracking-[-0.02em] text-[clamp(46px,7vw,96px)]">
-            {brand.titleBottom}
-          </h3>
-          <div className="mt-4 flex items-center gap-3">
-            <p className="font-sub text-[#2B1C0E] text-[clamp(16px,2.5vw,28px)]">
-              {brand.tagline}
-            </p>
-            {brand.showCupIcon && <FaCoffee className="w-7 h-7" color="#2B1C0E" />}
-          </div>
-        </div>
-      </div>
-
-      {/* Tarjeta contacto + banana */}
-      <div className="md:col-span-5 relative">
-        <div className="w-full h-full min-h-[280px] md:min-h-[340px] rounded-[28px] border-[6px] border-[#2B1C0E] bg-[#F4DFC6] p-6 md:p-8 shadow-[6px_6px_0px_0px_#2B1C0E] flex flex-col justify-center">
-          <div className="space-y-4 text-[#2B1C0E]">
-            <a
-              href={contactCard.phone.href}
-              className="flex items-center gap-3 text-[clamp(16px,2.5vw,28px)] font-heading"
-            >
-              <FaPhoneAlt className="w-5 h-5" />
-              <span>{contactCard.phone.label}</span>
-            </a>
-            <a
-              href={contactCard.email.href}
-              className="flex items-center gap-3 text-[clamp(16px,2.5vw,28px)] font-heading"
-            >
-              <FaEnvelope className="w-5 h-5" />
-              <span>{contactCard.email.label}</span>
-            </a>
-            <a
-              href={contactCard.address.href}
-              target="_blank"
-              className="flex items-center gap-3 text-[clamp(16px,2.5vw,28px)] font-heading"
-            >
-              <FaMapMarkerAlt className="w-5 h-5" />
-              <span className="whitespace-pre-line">{contactCard.address.label}</span>
-            </a>
-          </div>
-        </div>
-
-        {/* Banana (superpuesta al borde inferior derecho) */}
-        <div className="pointer-events-none absolute -bottom-4 right-2 md:top-1/2 -translate-y-1/2 transform md:right-0 w-[150px] sm:w-[180px] md:w-[220px]">
-          <div className="relative justify-center items-center h-[180px] sm:h-[210px] md:h-[200px]">
-            <Image
-              src={image.src}
-              alt={image.alt}
-              fill
-              sizes="(max-width: 768px) 40vw, (max-width: 1200px) 20vw, 220px"
-              className="object-contain"
-            />
-          </div>
-        </div>
-      </div>
-
-      {/* Navegación inferior en píldoras */}
-      <div className="md:col-span-12 mt-4 flex flex-wrap items-center justify-start gap-4 md:gap-6">
-        {nav.links.map((l, i) => {
-          const active = i === nav.activeIndex;
-          return (
-            <Link
-              key={l.href}
-              href={l.href}
-              className={`inline-flex items-center justify-center px-6 py-2 rounded-[9999px] border-[3px] shadow-[4px_4px_0px_0px_#2B1C0E] text-[clamp(14px,2vw,20px)] font-heading ${
-                active
-                  ? "bg-[#C65A1E] text-[#FFEFD0] border-[#2B1C0E]"
-                  : "bg-[#2B1C0E] text-[#F7D58A] border-[#2B1C0E]"
-              } hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-none transition-transform duration-150`}
-            >
-              {l.label}
-            </Link>
-          );
-        })}
-      </div>
+      <FooterBrandCard brand={brand} />
+      <FooterContactCard contactCard={contactCard} image={image} />
+      <FooterNavigation nav={nav} />
     </Section>
   );
 }

--- a/src/components/sections/footer/components/FooterBrandCard.jsx
+++ b/src/components/sections/footer/components/FooterBrandCard.jsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { FaCoffee } from "react-icons/fa";
+
+export default function FooterBrandCard({ brand }) {
+  return (
+    <div className="md:col-span-7">
+      <div className="w-full h-full min-h-[280px] md:min-h-[340px] rounded-[28px] border-[6px] border-[#2B1C0E] bg-[#F4DFC6] p-6 md:p-10 shadow-[6px_6px_0px_0px_#2B1C0E] flex flex-col justify-center">
+        <h3 className="font-heading text-[#2B1C0E] leading-[0.85] tracking-[-0.02em] text-[clamp(46px,7vw,96px)]">
+          {brand.titleTop}
+        </h3>
+        <h3 className="font-heading text-[#2B1C0E] leading-[0.85] tracking-[-0.02em] text-[clamp(46px,7vw,96px)]">
+          {brand.titleBottom}
+        </h3>
+        <div className="mt-4 flex items-center gap-3">
+          <p className="font-sub text-[#2B1C0E] text-[clamp(16px,2.5vw,28px)]">{brand.tagline}</p>
+          {brand.showCupIcon && <FaCoffee className="w-7 h-7" color="#2B1C0E" />}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/sections/footer/components/FooterContactCard.jsx
+++ b/src/components/sections/footer/components/FooterContactCard.jsx
@@ -1,0 +1,35 @@
+"use client";
+
+import Image from "next/image";
+import { FaPhoneAlt, FaEnvelope, FaMapMarkerAlt } from "react-icons/fa";
+import FooterContactLink from "./FooterContactLink";
+
+export default function FooterContactCard({ contactCard, image }) {
+  return (
+    <div className="md:col-span-5 relative">
+      <div className="w-full h-full min-h-[280px] md:min-h-[340px] rounded-[28px] border-[6px] border-[#2B1C0E] bg-[#F4DFC6] p-6 md:p-8 shadow-[6px_6px_0px_0px_#2B1C0E] flex flex-col justify-center">
+        <div className="space-y-4 text-[#2B1C0E]">
+          <FooterContactLink href={contactCard.phone.href} label={contactCard.phone.label} icon={FaPhoneAlt} />
+          <FooterContactLink href={contactCard.email.href} label={contactCard.email.label} icon={FaEnvelope} />
+          <FooterContactLink
+            href={contactCard.address.href}
+            label={contactCard.address.label}
+            icon={FaMapMarkerAlt}
+            target="_blank"
+          />
+        </div>
+      </div>
+      <div className="pointer-events-none absolute -bottom-4 right-2 md:top-1/2 -translate-y-1/2 transform md:right-0 w-[150px] sm:w-[180px] md:w-[220px]">
+        <div className="relative justify-center items-center h-[180px] sm:h-[210px] md:h-[200px]">
+          <Image
+            src={image.src}
+            alt={image.alt}
+            fill
+            sizes="(max-width: 768px) 40vw, (max-width: 1200px) 20vw, 220px"
+            className="object-contain"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/sections/footer/components/FooterContactLink.jsx
+++ b/src/components/sections/footer/components/FooterContactLink.jsx
@@ -1,0 +1,14 @@
+"use client";
+
+export default function FooterContactLink({ href, label, icon: Icon, target }) {
+  return (
+    <a
+      href={href}
+      target={target}
+      className="flex items-center gap-3 text-[clamp(16px,2.5vw,28px)] font-heading"
+    >
+      <Icon className="w-5 h-5" />
+      <span className="whitespace-pre-line">{label}</span>
+    </a>
+  );
+}

--- a/src/components/sections/footer/components/FooterNavLink.jsx
+++ b/src/components/sections/footer/components/FooterNavLink.jsx
@@ -1,0 +1,18 @@
+"use client";
+
+import Link from "next/link";
+
+export default function FooterNavLink({ link, active }) {
+  const baseClasses =
+    "inline-flex items-center justify-center px-6 py-2 rounded-[9999px] border-[3px] shadow-[4px_4px_0px_0px_#2B1C0E] text-[clamp(14px,2vw,20px)] font-heading transition-transform duration-150 hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-none";
+
+  const activeClasses = active
+    ? "bg-[#C65A1E] text-[#FFEFD0] border-[#2B1C0E]"
+    : "bg-[#2B1C0E] text-[#F7D58A] border-[#2B1C0E]";
+
+  return (
+    <Link href={link.href} className={`${baseClasses} ${activeClasses}`}>
+      {link.label}
+    </Link>
+  );
+}

--- a/src/components/sections/footer/components/FooterNavigation.jsx
+++ b/src/components/sections/footer/components/FooterNavigation.jsx
@@ -1,0 +1,13 @@
+"use client";
+
+import FooterNavLink from "./FooterNavLink";
+
+export default function FooterNavigation({ nav }) {
+  return (
+    <div className="md:col-span-12 mt-4 flex flex-wrap items-center justify-start gap-4 md:gap-6">
+      {nav.links.map((link, index) => (
+        <FooterNavLink key={link.href} link={link} active={index === nav.activeIndex} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/sections/hero/HeroSection.jsx
+++ b/src/components/sections/hero/HeroSection.jsx
@@ -1,8 +1,9 @@
 "use client";
 
-import Image from "next/image";
 import Section from "@/components/ui/Section";
 import { hero } from "@/lib/data";
+import HeroContent from "./components/HeroContent";
+import HeroIllustration from "./components/HeroIllustration";
 
 export default function HeroSection() {
   const { titleTop, titleMid, titleBottom, subtitle, image, ctas } = hero;
@@ -13,46 +14,12 @@ export default function HeroSection() {
       className="bg-[#E3551E] text-[#2B1C0E]"
       innerClassName="grid grid-cols-1 md:grid-cols-12 py-26 md:py-0 md:pt-10 items-stretch w-full mx-auto relative px-2 md:px-6 max-w-[1480px] gap-2 md:gap-20"
     >
-      {/* Texto */}
-      <div className="md:col-span-6 flex flex-col justify-center md:pt-6 ">
-        <h1 className="font-heading leading-[0.78] tracking-[-0.02em] text-[clamp(58px,15vw,15rem)] text-nowrap">
-          {titleTop}<br className="hidden md:block" /> {titleMid}<br /><span className="sm:w-full sm:text-center ">{titleBottom}</span>
-        </h1>
-        <p className="mt-2 md:mt-20 text-[#FFFFFF]/70 text-lg sm:text-xl md:text-2xl font-sub">{subtitle}</p>
-        <div className="mt-8 flex flex-col sm:flex-row gap-4 sm:gap-5">
-          <a
-            href={ctas.primary.href}
-            onClick={(e) => {
-              if (ctas.primary.href.startsWith("#")) {
-                e.preventDefault();
-                const id = ctas.primary.href.replace("#", "");
-                const section = document.getElementById(id);
-                section?.scrollIntoView({ behavior: "smooth", block: "start" });
-              }
-            }}
-            className="inline-flex items-center justify-center px-6 sm:px-7 py-3 rounded-[9999px] text-base sm:text-lg font-semibold bg-[#F7D58A] text-[#2B1C0E] border-[3px] border-[#2B1C0E] shadow-[4px_4px_0px_0px_#2B1C0E] hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-none transition-transform duration-150">{ctas.primary.label}</a>
-          <a
-            href={ctas.secondary.href}
-            onClick={(e) => {
-              if (ctas.primary.href.startsWith("#")) {
-                e.preventDefault();
-                const id = ctas.primary.href.replace("#", "");
-                const section = document.getElementById(id);
-                section?.scrollIntoView({ behavior: "smooth", block: "start" });
-              }
-            }}
-            className="inline-flex items-center justify-center px-6 sm:px-7 py-3 rounded-[9999px] text-base sm:text-lg font-semibold bg-[#B74728] text-[#FFFFFF] border-[3px] border-[#2B1C0E] shadow-[4px_4px_0px_0px_#2B1C0E] hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-none transition-transform duration-150">{ctas.secondary.label}</a>
-        </div>
-      </div>
-
-      {/* Banana */}
-      <div className="md:col-span-6 flex md:justify-end md:items-center">
-        <div className="relative w-full md:w-[min(60vw,860px)] lg:w-[min(56vw,980px)] ">
-          <div className=" h-[38vh] sm:h-[64vh] md:h-[min(80vh,820px)] lg:h-[min(86vh,920px)]">
-            <Image src={image.src} alt={image.alt} fill priority sizes="(max-width: 768px) 95vw, (max-width: 1200px) 60vw, 980px" className="object-contain mt-10 md:mt-0" />
-          </div>
-        </div>
-      </div>
+      <HeroContent
+        title={{ top: titleTop, mid: titleMid, bottom: titleBottom }}
+        subtitle={subtitle}
+        ctas={ctas}
+      />
+      <HeroIllustration image={image} />
     </Section>
   );
 }

--- a/src/components/sections/hero/components/HeroCTAButton.jsx
+++ b/src/components/sections/hero/components/HeroCTAButton.jsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useCallback } from "react";
+
+const baseClasses =
+  "inline-flex items-center justify-center px-6 sm:px-7 py-3 rounded-[9999px] text-base sm:text-lg font-semibold border-[3px] shadow-[4px_4px_0px_0px_#2B1C0E] transition-transform duration-150 hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-none";
+
+const variantClasses = {
+  primary: "bg-[#F7D58A] text-[#2B1C0E] border-[#2B1C0E]",
+  secondary: "bg-[#B74728] text-[#FFFFFF] border-[#2B1C0E]",
+};
+
+export default function HeroCTAButton({ href, label, variant = "primary" }) {
+  const handleClick = useCallback(
+    (event) => {
+      if (href.startsWith("#")) {
+        event.preventDefault();
+        const targetId = href.replace("#", "");
+        document.getElementById(targetId)?.scrollIntoView({
+          behavior: "smooth",
+          block: "start",
+        });
+      }
+    },
+    [href]
+  );
+
+  return (
+    <a href={href} onClick={handleClick} className={`${baseClasses} ${variantClasses[variant]}`}>
+      {label}
+    </a>
+  );
+}

--- a/src/components/sections/hero/components/HeroCTAs.jsx
+++ b/src/components/sections/hero/components/HeroCTAs.jsx
@@ -1,0 +1,24 @@
+"use client";
+
+import HeroCTAButton from "./HeroCTAButton";
+
+export default function HeroCTAs({ ctas }) {
+  const buttons = [
+    {
+      ...ctas.primary,
+      variant: "primary",
+    },
+    {
+      ...ctas.secondary,
+      variant: "secondary",
+    },
+  ];
+
+  return (
+    <div className="mt-8 flex flex-col sm:flex-row gap-4 sm:gap-5">
+      {buttons.map((button) => (
+        <HeroCTAButton key={button.href} {...button} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/sections/hero/components/HeroContent.jsx
+++ b/src/components/sections/hero/components/HeroContent.jsx
@@ -1,0 +1,15 @@
+"use client";
+
+import HeroTitle from "./HeroTitle";
+import HeroSubtitle from "./HeroSubtitle";
+import HeroCTAs from "./HeroCTAs";
+
+export default function HeroContent({ title, subtitle, ctas }) {
+  return (
+    <div className="md:col-span-6 flex flex-col justify-center md:pt-6">
+      <HeroTitle {...title} />
+      <HeroSubtitle text={subtitle} />
+      <HeroCTAs ctas={ctas} />
+    </div>
+  );
+}

--- a/src/components/sections/hero/components/HeroIllustration.jsx
+++ b/src/components/sections/hero/components/HeroIllustration.jsx
@@ -1,0 +1,22 @@
+"use client";
+
+import Image from "next/image";
+
+export default function HeroIllustration({ image }) {
+  return (
+    <div className="md:col-span-6 flex md:justify-end md:items-center">
+      <div className="relative w-full md:w-[min(60vw,860px)] lg:w-[min(56vw,980px)]">
+        <div className="h-[38vh] sm:h-[64vh] md:h-[min(80vh,820px)] lg:h-[min(86vh,920px)]">
+          <Image
+            src={image.src}
+            alt={image.alt}
+            fill
+            priority
+            sizes="(max-width: 768px) 95vw, (max-width: 1200px) 60vw, 980px"
+            className="object-contain mt-10 md:mt-0"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/sections/hero/components/HeroSubtitle.jsx
+++ b/src/components/sections/hero/components/HeroSubtitle.jsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function HeroSubtitle({ text }) {
+  return (
+    <p className="mt-2 md:mt-20 text-[#FFFFFF]/70 text-lg sm:text-xl md:text-2xl font-sub">
+      {text}
+    </p>
+  );
+}

--- a/src/components/sections/hero/components/HeroTitle.jsx
+++ b/src/components/sections/hero/components/HeroTitle.jsx
@@ -1,0 +1,12 @@
+"use client";
+
+export default function HeroTitle({ top, mid, bottom }) {
+  return (
+    <h1 className="font-heading leading-[0.78] tracking-[-0.02em] text-[clamp(58px,15vw,15rem)] text-nowrap">
+      {top}
+      <br className="hidden md:block" /> {mid}
+      <br />
+      <span className="sm:w-full sm:text-center">{bottom}</span>
+    </h1>
+  );
+}

--- a/src/components/sections/how-it-works/HowItWorks.jsx
+++ b/src/components/sections/how-it-works/HowItWorks.jsx
@@ -1,81 +1,27 @@
 "use client";
 
-import Image from "next/image";
 import Section from "@/components/ui/Section";
 import { howItWorks } from "@/lib/data";
-import Button from "@/components/ui/Button";
+import HowItWorksTitle from "./components/HowItWorksTitle";
+import HowItWorksDivider from "./components/HowItWorksDivider";
+import HowItWorksSteps from "./components/HowItWorksSteps";
+import HowItWorksCtaBand from "./components/HowItWorksCtaBand";
 
 export default function HowItWorks() {
-    const { id, title, steps, ctaBand } = howItWorks;
+  const { id, title, steps, ctaBand } = howItWorks;
 
-    return (
-        <Section
-            id={id}
-            className="bg-[#3D1C0F] text-[#F4DEAA]"
-            innerClassName="w-full mx-auto relative px-2 md:px-6 max-w-[1480px] py-20 md:py-0 md:pt-0 pb-20 md:pb-0"
-        >
-            {/* Contenedor con marco retro */}
-            <div className="relative w-full p-0 md:p-0 ">
-                {/* Ornamentos de las esquinas */}
-
-
-                {/* Título */}
-                <h2 className="font-heading text-[#F4DEAA] leading-[0.9] tracking-[-0.02em] text-center text-[clamp(40px,7vw,6rem)] mb-6 md:mb-10">
-                    {title}
-                </h2>
-
-                {/* Línea decorativa bajo el título */}
-                <div className="h-[3px] md:h-[6px] w-full rounded-full bg-[#D18B28] mb-8 md:mb-12" />
-
-                {/* Grid de pasos */}
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-10 md:gap-20">
-                    {steps.map((step, i) => (
-                        <div
-                            key={i}
-                            className="flex flex-col items-center text-center px-2 md:px-0 relative"
-                        >
-                            {/* Divisor vertical entre columnas en desktop */}
-
-                            {/* Ilustración */}
-                            <div className="relative w-full max-w-[380px] mx-auto">
-                                <div className="relative h-[220px] sm:h-[240px] md:h-[260px] lg:h-[300px] 2xl:h-[400px]">
-                                    <Image
-                                        src={step.image.src}
-                                        alt={step.image.alt}
-                                        fill
-                                        sizes="(max-width: 768px) 90vw, (max-width: 1200px) 30vw, 380px"
-                                        className="object-contain"
-                                    />
-                                </div>
-                            </div>
-                            {/* Texto del paso */}
-                            <p className="mt-4 font-sub text-[#F4DEAA] text-[clamp(18px,2.6vw,28px)] leading-tight">
-                                {step.title}
-                            </p>
-                        </div>
-                    ))}
-                </div>
-
-                {/* Banda CTA inferior */}
-                <div className="relative mt-12 md:mt-16 flex justify-center ">
-                    {/* Línea horizontal que se extiende */}
-
-                    {/* Pill encima de la línea */}
-                    <div className="relative inline-flex items-center gap-4 rounded-full border-[6px] border-[#D18B28] px-6 md:px-10 py-0 md:py-3 bg-[#D18B28]">
-                        <span className="font-heading text-[#3D1C0F] text-[clamp(20px,3vw,36px)] font-bold text-nowrap">
-                            {ctaBand.leftLabel}
-                            <br className="block md:hidden" />
-                            <span> a partir de $100</span>
-                        </span>
-
-                        <a
-                            href={ctaBand.href}
-                            className="inline-flex items-center justify-center px-4 sm:px-7 py-3 rounded-[9999px] text-base sm:text-lg font-semibold bg-[#F7D58A] text-[#2B1C0E] border-[3px] border-[#2B1C0E] shadow-[4px_4px_0px_0px_#2B1C0E] hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-none transition-transform duration-150 text-nowrap">Aprovechar
-                        </a>
-                    </div>
-                </div>
-
-            </div>
-        </Section>
-    );
+  return (
+    <Section
+      id={id}
+      className="bg-[#3D1C0F] text-[#F4DEAA]"
+      innerClassName="w-full mx-auto relative px-2 md:px-6 max-w-[1480px] py-20 md:py-0 md:pt-0 pb-20 md:pb-0"
+    >
+      <div className="relative w-full">
+        <HowItWorksTitle title={title} />
+        <HowItWorksDivider />
+        <HowItWorksSteps steps={steps} />
+        <HowItWorksCtaBand cta={ctaBand} />
+      </div>
+    </Section>
+  );
 }

--- a/src/components/sections/how-it-works/components/HowItWorksCtaBand.jsx
+++ b/src/components/sections/how-it-works/components/HowItWorksCtaBand.jsx
@@ -1,0 +1,18 @@
+"use client";
+
+import HowItWorksCtaButton from "./HowItWorksCtaButton";
+
+export default function HowItWorksCtaBand({ cta }) {
+  return (
+    <div className="relative mt-12 md:mt-16 flex justify-center">
+      <div className="relative inline-flex items-center gap-4 rounded-full border-[6px] border-[#D18B28] px-6 md:px-10 py-0 md:py-3 bg-[#D18B28]">
+        <span className="font-heading text-[#3D1C0F] text-[clamp(20px,3vw,36px)] font-bold text-nowrap">
+          {cta.leftLabel}
+          <br className="block md:hidden" />
+          <span> a partir de $100</span>
+        </span>
+        <HowItWorksCtaButton href={cta.button.href} label={cta.button.label} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/sections/how-it-works/components/HowItWorksCtaButton.jsx
+++ b/src/components/sections/how-it-works/components/HowItWorksCtaButton.jsx
@@ -1,0 +1,12 @@
+"use client";
+
+export default function HowItWorksCtaButton({ href, label }) {
+  return (
+    <a
+      href={href}
+      className="inline-flex items-center justify-center px-4 sm:px-7 py-3 rounded-[9999px] text-base sm:text-lg font-semibold bg-[#F7D58A] text-[#2B1C0E] border-[3px] border-[#2B1C0E] shadow-[4px_4px_0px_0px_#2B1C0E] hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-none transition-transform duration-150 text-nowrap"
+    >
+      {label}
+    </a>
+  );
+}

--- a/src/components/sections/how-it-works/components/HowItWorksDivider.jsx
+++ b/src/components/sections/how-it-works/components/HowItWorksDivider.jsx
@@ -1,0 +1,5 @@
+"use client";
+
+export default function HowItWorksDivider() {
+  return <div className="h-[3px] md:h-[6px] w-full rounded-full bg-[#D18B28] mb-8 md:mb-12" />;
+}

--- a/src/components/sections/how-it-works/components/HowItWorksStepCard.jsx
+++ b/src/components/sections/how-it-works/components/HowItWorksStepCard.jsx
@@ -1,0 +1,24 @@
+"use client";
+
+import Image from "next/image";
+
+export default function HowItWorksStepCard({ step }) {
+  return (
+    <div className="flex flex-col items-center text-center px-2 md:px-0 relative">
+      <div className="relative w-full max-w-[380px] mx-auto">
+        <div className="relative h-[220px] sm:h-[240px] md:h-[260px] lg:h-[300px] 2xl:h-[400px]">
+          <Image
+            src={step.image.src}
+            alt={step.image.alt}
+            fill
+            sizes="(max-width: 768px) 90vw, (max-width: 1200px) 30vw, 380px"
+            className="object-contain"
+          />
+        </div>
+      </div>
+      <p className="mt-4 font-sub text-[#F4DEAA] text-[clamp(18px,2.6vw,28px)] leading-tight">
+        {step.title}
+      </p>
+    </div>
+  );
+}

--- a/src/components/sections/how-it-works/components/HowItWorksSteps.jsx
+++ b/src/components/sections/how-it-works/components/HowItWorksSteps.jsx
@@ -1,0 +1,13 @@
+"use client";
+
+import HowItWorksStepCard from "./HowItWorksStepCard";
+
+export default function HowItWorksSteps({ steps }) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-10 md:gap-20">
+      {steps.map((step, index) => (
+        <HowItWorksStepCard key={index} step={step} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/sections/how-it-works/components/HowItWorksTitle.jsx
+++ b/src/components/sections/how-it-works/components/HowItWorksTitle.jsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function HowItWorksTitle({ title }) {
+  return (
+    <h2 className="font-heading text-[#F4DEAA] leading-[0.9] tracking-[-0.02em] text-center text-[clamp(40px,7vw,6rem)] mb-6 md:mb-10">
+      {title}
+    </h2>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 // tailwind.config.mjs
 /** @type {import('tailwindcss').Config} */
-export default {
+const config = {
   content: [
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
@@ -48,3 +48,5 @@ export default {
   },
   plugins: [],
 };
+
+export default config;


### PR DESCRIPTION
## Summary
- Break the hero section into focused title, CTA, and illustration microcomponents with shared smooth scroll handling.
- Extract about, contact, how-it-works, and footer subsections into reusable microcomponents to simplify layout composition.
- Silence the lingering ESLint warning by exporting the Tailwind config via an intermediate constant.

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca7d8c295083328828f5f0c9d82133